### PR TITLE
Wrike 415858226: Fix conditional that checks if external Listrak script is loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Check to make sure Listrak script is loaded before activating event listener
+
 ## [0.0.1] - 2020-01-31
 
 ### Added

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -96,6 +96,6 @@ export function handleEvents(event: PixelMessage) {
   }
 }
 
-if (canUseDOM && _ltk) {
+if (canUseDOM && typeof _ltk != 'undefined') {
   window.addEventListener('message', handleEvents)
 }


### PR DESCRIPTION
Thiago noticed that if a Listrak merchant ID is not provided in the app settings, the site errors out due to bad syntax when checking for the `_ltk` object. I have updated the conditional to check that the typeof `_ltk` is not 'undefined'. 

Workspace showing the problem: https://listrakprod--worldwidegolf.myvtex.com/
Workspace with new version linked: https://listrak--worldwidegolf.myvtex.com/