### PR TITLE
Wrike 470199251:  Remove billing options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- Removed billing options from manifest
+
 ## [0.0.2] - 2020-02-10
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -4,13 +4,6 @@
   "version": "0.0.2",
   "title": "Listrak",
   "description": "An implementation of Listrak conversion tracking",
-  "billingOptions": {
-    "termsURL": "",
-    "support": {
-      "url": "https://support.vtex.com/hc/requests"
-    },
-    "free": true
-  },
   "builders": {
     "react": "3.x",
     "store": "0.x",


### PR DESCRIPTION
The presence of billingOptions in an app manifest, even if the price is set to "free", results in the builder-hub throwing an error when the app is added as a dependency of another app (for example a store-theme). 

I have reported this as a bug to the store team, and in the meantime this PR removes the billingOptions section from the manifest.