### PR TITLE
Add Listrak email subscription integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Configuration to separate abandonment and newsletter subscription events
+
 ## [1.2.0] - 2021-03-08
 
 ### Added
 
-- `newsletterInput` Pixel event to handle newsletter input. 
+- `newsletterInput` Pixel event to handle newsletter input.
 
 ## [1.1.1] - 2020-08-31
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,11 @@ This app provides pixel integration for Listrak metrics and cart abandonment fun
 
 - **Merchant ID**: Input your Listrak Merchant ID here.
 
-- **Email Input Field IDs**: Listrak's cart abandonment feature works in part by capturing email addresses when shopper type them into certain fields. By default, the email input field with ID "newsletter-input" will be tracked, but additional field IDs can be specified here, separated with commas and no spaces like `emailField1,emailField2`.
+- **Subscription Point ID**: Input your `Subscribe ID` of the email Subscription Point from your Listrak account.
+
+- **Subscription Form IDs**: To capture a shoppers opt-in to an email subscription, enter the field IDs associated with the subscription form email input and submit button. Enter both IDs separated with commas and no spaces like `emailInputId,submitButtonId`. **If the Newsletter block from the `vtex.store-component` is used, no entry is necessary**.
+
+- **Email Input Field IDs**: Listrak's cart abandonment feature works in part by capturing email addresses when shoppers type them into certain fields. These field IDs can be specified here, separated with commas and no spaces like `emailField1,emailField2`.
 
 - **Preference Center Name**: This app creates a new store route with the path `/preference-center` which displays the Listrak Preference Center. Referencing your Listrak Preference Center integration instructions, input the value for the `data-ltk-prefcenter` attribute of the Preference Center div here.
 

--- a/manifest.json
+++ b/manifest.json
@@ -25,9 +25,19 @@
         "description": "Enter your Merchant ID for Listrak",
         "type": "string"
       },
+      "subscriptionPoint": {
+        "title": " Subscription Point ID",
+        "description": "Enter the `Subscribe ID` of the email Subscription Point from your Listrak account",
+        "type": "string"
+      },
+      "subscriptionIds": {
+        "title": "Subscription Form IDs",
+        "description": "Enter IDs of any subscription email input and associated submit button, separated by commas",
+        "type": "string"
+      },
       "emailInputIds": {
-        "title": "Email Input Field IDs",
-        "description": "Enter IDs of any email input fields you wish to be tracked, separated by commas. 'newsletter-input' is always tracked",
+        "title": "Email Input Field IDs for Abandonment",
+        "description": "Enter IDs of any email input fields you wish to be tracked for abandonment, separated by commas",
         "type": "string"
       },
       "prefCenterName": {

--- a/pixel/head.html
+++ b/pixel/head.html
@@ -3,6 +3,8 @@
     var merchantId = '{{settings.merchantId}}'
     var prefCenter = '{{settings.prefCenterName}}'
     var emailIds = '{{settings.emailInputIds}}'
+    var subscriptionPoint = '{{settings.subscriptionPoint}}'
+    var subscriptionIds = '{{settings.subscriptionIds}}'
     var useRefIdSetting = '{{settings.useRefId}}'
     if (!merchantId) {
       console.error(
@@ -15,6 +17,20 @@
       window.__listrak_pref_center = prefCenter
       window.__listrak_email_ids = emailIds
         ? decodeURIComponent(emailIds).split(',')
+        : ''
+      window.__listrak_subscription_ids = subscriptionIds
+        ? decodeURIComponent(subscriptionIds)
+            .split(',')
+            .reduce(
+              (acc, curr, i, ids) =>
+                i % 2 === 0
+                  ? acc
+                  : [...acc, { input: ids[i - 1], submit: curr }],
+              []
+            )
+        : []
+      window.__listrak_subscription_point = subscriptionPoint
+        ? decodeURIComponent(subscriptionPoint)
         : ''
       window.__listrak_useRefIdSetting = useRefIdSetting
         ? JSON.parse(useRefIdSetting)

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -72,11 +72,26 @@ export function handleEvents(event: PixelMessage) {
         }
         function ltkCode() {
           _ltk_util.ready(() => {
+            const subscriptionPoint = window.__listrak_subscription_point
+            const subscriptionIds = window.__listrak_subscription_ids
+            if (subscriptionPoint && subscriptionIds.length > 0) {
+              subscriptionIds.forEach(group => {
+                _ltk.Signup.New(
+                  subscriptionPoint,
+                  group.input,
+                  _ltk.Signup.TYPE.CLICK,
+                  group.submit,
+                  'email'
+                )
+              })
+            }
+
             if (window.__listrak_email_ids.length > 0) {
               window.__listrak_email_ids.forEach(emailId => {
                 _ltk.SCA.CaptureEmail(emailId)
               })
             }
+
             _ltk.Activity.AddPageBrowse()
             _ltk.Activity.Submit()
           })
@@ -243,7 +258,24 @@ export function handleEvents(event: PixelMessage) {
         }
         function ltkCode() {
           _ltk_util.ready(() => {
-            _ltk.SCA.CaptureEmail('newsletter-input')
+            const subscriptionPoint = window.__listrak_subscription_point
+            const newsletterInputId = window.__listrak_email_ids.some(
+              id => id === 'newsletter-input'
+            )
+
+            if (subscriptionPoint) {
+              _ltk.Signup.New(
+                subscriptionPoint,
+                `[class^=vtex-store-components][class*=-newsletter] form input`,
+                _ltk.Signup.TYPE.CLICK,
+                `[class^=vtex-store-components][class*=-newsletter] form button`,
+                'email'
+              )
+            }
+
+            if (newsletterInputId) {
+              _ltk.SCA.CaptureEmail('newsletter-input')
+            }
           })
         }
       })()

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -3,6 +3,8 @@ interface Window extends Window {
   __listrak_merchant_id: string
   __listrak_pref_center: string
   __listrak_email_ids: string[]
+  __listrak_subscription_point: string
+  __listrak_subscription_ids: Array<{ input: string; submit: string }>
   __listrak_useRefIdSetting: boolean
 }
 


### PR DESCRIPTION
- Adds the Listrak email subscription capture and associated app settings. 

To test, use the workspace below to enter an email in the newsletter subscription form and submit. Filter the network tab in the dev tools with `listrak` to see the request.

[workspace](https://sdb--eriksbikeshop.myvtex.com/)

![Screenshot from 2021-03-18 07-53-46](https://user-images.githubusercontent.com/22715037/111637586-30133300-87bf-11eb-9219-9fd994250f72.png)

