### PR TITLE
Add product specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,34 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Listrak product payload fields (Category, Sub category, Meta 1, Meta 2, Meta 3) in the app settings to make it available for the admin to change.
+
+## [2.0.3] - 2022-02-10
+
+### Added
+
+- CSS Handle
+
+### Added
+
+- Quality engineering actions
+
+## [2.0.2] - 2021-09-27
+
+### Added
+
+- App store metadata
+
+## [2.0.1] - 2021-08-23
+
+### Added
+
+- Crowdin file
+
+## [2.0.0] - 2021-06-22
+
+### Added
+
 - Send Sku/Order/Product data to Listrak API
 
 ## [1.3.0] - 2021-03-18

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,21 @@ The settings below are only needed if you have created a [Listrak Data Integrati
 
 - **Full Catalog Import**: Send your entire product catalog to Listrak. This will happen on the first SKU update after enabling the option.
 
+**Listrak Fields and Values (Optional)** 
+
+The following optional settings allow you to map VTEX product specifications to specific Listrak fields. If left blank, they will be filled according to the default behavior explained below:
+
+- **Category**: Input the name of the product specification field containing the product's main category. If left blank, this will be automatically set as the first category that the product belongs to. 
+
+- **Sub Category**: Input the name of the product specification field containing the product's secondary category. If left blank, this will be automatically set as "Type/Silhouette".
+
+- **Meta 1**: Input the name of the product specification field containing any additional data you wish to send. If left blank, this will be automatically set as a pipe-separated list of the item's unique SKU specifications.
+
+- **Meta 2**: Input the name of the product specification field containing any additional data you wish to send. If left blank, this will be automatically set with a placeholder value of "meta_2".
+
+- **Meta 3**: Input the name of the product specification field containing any additional data you wish to send. If left blank, this will be automatically set with a placeholder value of "meta_3".
+
+
 ## (Optional) On-Site Recommendation Integration Block
 
 To use this optional block in your `store-theme`, you must add the Listrak app to your `store-theme`'s peer dependencies in `manifest.json`:

--- a/manifest.json
+++ b/manifest.json
@@ -120,6 +120,38 @@
         "description": "Import your full product catalog to Listrak on the next SKU update",
         "type": "boolean",
         "default": false
+      },
+      "fields": {
+        "title": "Listrak Fields & Values",
+        "description": "This will map the vtex product specifications with listrak fields",
+        "type": "object",
+        "properties": {
+          "category": {
+            "title": "Category",
+            "description": "Product specification value for category fields in Listrak payload",
+            "type": "string"
+          },
+          "subcategory": {
+            "title": "Sub Category",
+            "description": "Product specification value for sub category fields in Listrak payload",
+            "type": "string"
+          },
+          "meta1": {
+            "title": "Meta 1",
+            "description": "Product specification value for meta1 fields in Listrak payload",
+            "type": "string"
+          },
+          "meta2": {
+            "title": "Meta 2",
+            "description": "Product specification value for meta2 fields in Listrak payload",
+            "type": "string"
+          },
+          "meta3": {
+            "title": "Meta 3",
+            "description": "Product specification value for meta3 fields in Listrak payload",
+            "type": "string"
+          }
+        }
       }
     }
   },

--- a/node/middlewares/product.ts
+++ b/node/middlewares/product.ts
@@ -47,7 +47,14 @@ const getUniqueSpecifications = (SkuSpecifications: Specification[]) => {
     .join(' | ')
 }
 
-const buildListrakProduct = (sku: Product, stock: StockItem) => {
+const buildListrakProduct = (
+  sku: Product,
+  stock: StockItem,
+  settings: Settings
+) => {
+  const categoryValue =
+    sku.ProductCategories[Object.keys(sku.ProductCategories).pop() as string]
+  const metaValue = getUniqueSpecifications(sku.SkuSpecifications)
   return {
     brand: sku.BrandName,
     description: sku.ProductDescription,
@@ -63,14 +70,28 @@ const buildListrakProduct = (sku: Product, stock: StockItem) => {
     linkUrl: sku.DetailUrl,
     price: stock.listPrice / 100,
     salePrice: stock.price / 100,
-    category:
-      sku.ProductCategories[Object.keys(sku.ProductCategories).pop() as string],
+    category: settings.fields?.category
+      ? getSpecification(sku.ProductSpecifications, settings.fields?.category)
+      : categoryValue,
     gender: getGender(sku),
     onSale: onSale(sku),
-    subCategory: getSpecification(sku.ProductSpecifications, 'Type/Silhouette'),
+    subCategory: getSpecification(
+      sku.ProductSpecifications,
+      settings.fields?.subcategory || 'Type/Silhouette'
+    ),
     color: getSpecification(sku.SkuSpecifications, 'Size'),
     size: getSpecification(sku.SkuSpecifications, 'Color'),
-    meta1: getUniqueSpecifications(sku.SkuSpecifications),
+    meta1: settings.fields?.meta1
+      ? getSpecification(sku.ProductSpecifications, settings.fields?.meta1)
+      : metaValue,
+    meta2: getSpecification(
+      sku.ProductSpecifications,
+      settings.fields?.meta2 || 'meta_2'
+    ),
+    meta3: getSpecification(
+      sku.ProductSpecifications,
+      settings.fields?.meta3 || 'meta_3'
+    ),
   }
 }
 
@@ -127,7 +148,7 @@ export async function productHandler(
     const [stock] = stockResponse.items
 
     try {
-      listrakProduct = buildListrakProduct(sku, stock)
+      listrakProduct = buildListrakProduct(sku, stock, appSettings)
     } catch (error) {
       logger.error({
         error,

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -3,8 +3,16 @@ interface Settings {
   listrakToken: ListrakToken
   listrakId?: string
   listrakSecret?: string
+  fields?: Fields
 }
 
+interface Fields {
+  category?: string
+  subcategory?: string
+  meta1?: string
+  meta2?: string
+  meta3?: string
+}
 interface DefaultSettings extends Settings {
   listrakToken: ListrakToken | null
 }


### PR DESCRIPTION
Created fields in admin settings to change the Listrak product payload fields
Fields Used: Category, Subcategory, Meta1, Meta2, Meta3

*Screen Shot*

![Listrak-product-specification](https://user-images.githubusercontent.com/87298269/147239576-b17cabe3-368c-4029-b79d-8f7b1d3ef967.png)

